### PR TITLE
First cleanliness pass

### DIFF
--- a/Assets/Battle/BattleState.cs
+++ b/Assets/Battle/BattleState.cs
@@ -10,21 +10,4 @@ public class BattleState : SceneLoadingGameplayState
     {
         // TODO: Enable battle controls
     }
-
-    public override IEnumerator ExitState(IGameplayState nextState)
-    {
-        if (nextState != null)
-        {
-            yield return SceneHelperInstance.TransitionsInstance.TransitionIn();
-        }
-
-        yield return base.ExitState(nextState);
-    }
-
-    public override IEnumerator StartState(GlobalStateMachine globalStateMachine, IGameplayState previousState)
-    {
-        yield return base.StartState(globalStateMachine, previousState);
-
-        yield return SceneHelperInstance.TransitionsInstance.ContinueTransitionYieldUntilInputsOK();
-    }
 }

--- a/Assets/Input/BufferedInput.cs
+++ b/Assets/Input/BufferedInput.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class BufferedInput
+{
+    public InputAction MappedAction { get; set; }
+    public Func<IEnumerator> FunctionToPerform { get; set; }
+
+    public BufferedInput(InputAction mappedAction, Func<IEnumerator> functionToPerform)
+    {
+        MappedAction = mappedAction;
+        FunctionToPerform = functionToPerform;
+    }
+}

--- a/Assets/Input/BufferedInput.cs.meta
+++ b/Assets/Input/BufferedInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f5c3d25d6f002840921fe8bbb912a4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Input/InputStack.cs
+++ b/Assets/Input/InputStack.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class InputStack
+{
+    private List<BufferedInput> inputs { get; set; } = new List<BufferedInput>();
+
+    public void Remove(InputAction byInputAction)
+    {
+        inputs.RemoveAll(bi => bi.MappedAction == byInputAction);
+    }
+
+    public void Add(BufferedInput toAdd)
+    {
+        // Already in the list? Ignore instead of adding
+        if (inputs.Any((bi) => bi.MappedAction == toAdd.MappedAction))
+        {
+            return;
+        }
+
+        inputs.Add(toAdd);
+    }
+
+    public BufferedInput CurrentInput
+    {
+        get
+        {
+            if (inputs.Any())
+            {
+                return inputs.Last();
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Input/InputStack.cs.meta
+++ b/Assets/Input/InputStack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1e0eea2c7ffe85468193a0fbe40c7fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Labyrinth/Data/DirectionExtensions.cs
+++ b/Assets/Labyrinth/Data/DirectionExtensions.cs
@@ -154,4 +154,26 @@ public static class DirectionExtensions
                 return 270f;
         }
     }
+
+    /// <summary>
+    /// Given a direction you're facing, and a relative direction to move, return a step in the relative direction.
+    /// </summary>
+    /// <param name="facing">The cardinal direction being faced.</param>
+    /// <param name="relativeDirection">The direction to step.</param>
+    /// <returns>One step in the appropriate direction.</returns>
+    public static Vector3Int EvaluateRelativeDirection(this Direction facing, RelativeDirection relativeDirection)
+    {
+        switch (relativeDirection)
+        {
+            default:
+            case RelativeDirection.Forward:
+                return facing.Forward();
+            case RelativeDirection.Right:
+                return facing.Right();
+            case RelativeDirection.Backward:
+                return facing.Backward();
+            case RelativeDirection.Left:
+                return facing.Left();
+        }
+    }
 }

--- a/Assets/Labyrinth/Data/RelativeDirection.cs
+++ b/Assets/Labyrinth/Data/RelativeDirection.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Describes a direction relative to the current facing of an object.
+/// </summary>
+public enum RelativeDirection
+{
+    Forward,
+    Right,
+    Backward,
+    Left
+}

--- a/Assets/Labyrinth/Data/RelativeDirection.cs.meta
+++ b/Assets/Labyrinth/Data/RelativeDirection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50acb71fdf7122248841a27bfae7aefa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Labyrinth/LabyrinthInputHandler.cs
+++ b/Assets/Labyrinth/LabyrinthInputHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using static WarrencrawlInputs;
@@ -31,9 +32,11 @@ public class LabyrinthInputHandler : MonoBehaviour, ILabyrinthActions
     bool initialized { get; set; } = false;
 
     /// <summary>
-    /// A function that creates an IEnumerator to run a coroutine with.
+    /// The buffered inputs for the player.
+    /// Each input is stacked on top of eachother, with the top most one being evaluated in <see cref="Update"/>.
+    /// These are present until the relevant input is not being held down.
     /// </summary>
-    Func<IEnumerator> bufferedAction { get; set; }
+    InputStack bufferedActions { get; set; } = new InputStack();
 
     /// <summary>
     /// Initializes the Input Handler with everything it needs to run.
@@ -57,13 +60,14 @@ public class LabyrinthInputHandler : MonoBehaviour, ILabyrinthActions
             return;
         }
 
-        if (bufferedAction == null)
+        if (bufferedActions.CurrentInput == null)
         {
             return;
         }
 
         animating = true;
-        sceneHelperInstance.StartCoroutine(bufferedAction());
+        BufferedInput bufferedInput = bufferedActions.CurrentInput;
+        sceneHelperInstance.StartCoroutine(bufferedInput.FunctionToPerform());
     }
 
     public void OnForward(InputAction.CallbackContext context)
@@ -121,11 +125,11 @@ public class LabyrinthInputHandler : MonoBehaviour, ILabyrinthActions
     {
         if (context.canceled)
         {
-            bufferedAction = null;
+            bufferedActions.Remove(context.action);
             return;
         }
 
-        bufferedAction = toApply;
+        bufferedActions.Add(new BufferedInput(context.action, toApply));
     }
 
     /// <summary>

--- a/Assets/Labyrinth/LabyrinthInputHandler.cs
+++ b/Assets/Labyrinth/LabyrinthInputHandler.cs
@@ -68,22 +68,22 @@ public class LabyrinthInputHandler : MonoBehaviour, ILabyrinthActions
 
     public void OnForward(InputAction.CallbackContext context)
     {
-        MoveDirection(context, referencedState.PointOfViewInstance.CurFacing.Forward());
+        MoveDirection(context, RelativeDirection.Forward);
     }
 
     public void OnBackward(InputAction.CallbackContext context)
     {
-        MoveDirection(context, referencedState.PointOfViewInstance.CurFacing.Backward());
+        MoveDirection(context, RelativeDirection.Backward);
     }
 
     public void OnRight(InputAction.CallbackContext context)
     {
-        MoveDirection(context, referencedState.PointOfViewInstance.CurFacing.Right());
+        MoveDirection(context, RelativeDirection.Right);
     }
 
     public void OnLeft(InputAction.CallbackContext context)
     {
-        MoveDirection(context, referencedState.PointOfViewInstance.CurFacing.Left());
+        MoveDirection(context, RelativeDirection.Left);
     }
 
     public void OnRotateRight(InputAction.CallbackContext context)
@@ -107,9 +107,9 @@ public class LabyrinthInputHandler : MonoBehaviour, ILabyrinthActions
         sceneHelperInstance.StartCoroutine(referencedState.Interact());
     }
 
-    void MoveDirection(InputAction.CallbackContext context, Vector3Int toMove)
+    void MoveDirection(InputAction.CallbackContext context, RelativeDirection relativeMovement)
     {
-        ApplyCoroutineContinuously(context, () => referencedState.Step(toMove));
+        ApplyCoroutineContinuously(context, () => referencedState.Step(referencedState.PointOfViewInstance.CurFacing.EvaluateRelativeDirection(relativeMovement)));
     }
 
     /// <summary>

--- a/Assets/Labyrinth/LabyrinthState.cs
+++ b/Assets/Labyrinth/LabyrinthState.cs
@@ -139,30 +139,16 @@ public class LabyrinthState : SceneLoadingGameplayState
 
         PointOfViewInstance.transform.rotation = Quaternion.Euler(0, PointOfViewInstance.CurFacing.Degrees(), 0);
         PointOfViewInstance.transform.position = cellAtStart.Worldspace;
-
-        yield return SceneHelperInstance.TransitionsInstance.ContinueTransitionYieldUntilInputsOK();
     }
 
     public override IEnumerator ExitState(IGameplayState nextState)
     {
-        if (nextState != null)
-        {
-            yield return SceneHelperInstance.TransitionsInstance.TransitionIn();
-        }
-
-        yield return base.ExitState(nextState);
-
         if (LoadedScene.HasValue)
         {
             yield return Addressables.UnloadSceneAsync(LoadedScene.Value);
         }
-    }
 
-    public override IEnumerator TransitionUp(IGameplayState nextState)
-    {
-        yield return base.TransitionUp(nextState);
-
-        yield return SceneHelperInstance.TransitionsInstance.TransitionIn();
+        yield return base.ExitState(nextState);
     }
 
     public override void SetControls(WarrencrawlInputs controls)

--- a/Assets/Labyrinth/LabyrinthState.cs
+++ b/Assets/Labyrinth/LabyrinthState.cs
@@ -106,10 +106,13 @@ public class LabyrinthState : SceneLoadingGameplayState
             }
         }
 
+        if (PointOfViewInstance == null)
+        {
+            PointOfViewInstance = GameObject.FindObjectOfType<PointOfView>();
+            PointOfViewInstance.CurFacing = Direction.North;
+            PointOfViewInstance.CurCoordinates = CellCoordinates.Origin;
+        }
         ActiveCombatClock = new CombatClock();
-        PointOfViewInstance = GameObject.FindObjectOfType<PointOfView>();
-        PointOfViewInstance.CurFacing = Direction.North;
-        PointOfViewInstance.CurCoordinates = CellCoordinates.Origin;
     }
 
     public override IEnumerator StartState(GlobalStateMachine globalStateMachine, IGameplayState previousState)

--- a/Assets/StateManagement/GlobalStateMachine.cs
+++ b/Assets/StateManagement/GlobalStateMachine.cs
@@ -58,6 +58,7 @@ public class GlobalStateMachine
         IGameplayState oldState = CurrentState;
         if (oldState != null)
         {
+            yield return oldState.AnimateTransitionOut(newState);
             yield return oldState.ExitState(newState);
             PresentStates.Pop();
         }
@@ -75,7 +76,8 @@ public class GlobalStateMachine
     public IEnumerator PushNewState(IGameplayState newState)
     {
         IGameplayState oldState = CurrentState;
-        yield return oldState?.TransitionUp(newState);
+        yield return oldState?.AnimateTransitionOut(newState);
+        yield return oldState?.ChangeUp(newState);
         PresentStates.Push(newState);
         yield return WarmUpAndStartCurrentState(oldState);
     }
@@ -90,6 +92,7 @@ public class GlobalStateMachine
         PresentStates.Pop();
 
         PresentStates.TryPeek(out IGameplayState nextState);
+        yield return oldState?.AnimateTransitionOut(nextState);
         yield return oldState?.ExitState(nextState);
 
         yield return WarmUpAndStartCurrentState(oldState);
@@ -107,6 +110,7 @@ public class GlobalStateMachine
         }
 
         yield return CurrentState.Load();
+        yield return CurrentState.AnimateTransitionIn(lastState);
         CurrentState.SetControls(lastActiveControls);
         yield return CurrentState.StartState(this, lastState);
     }

--- a/Assets/StateManagement/IGameplayState.cs
+++ b/Assets/StateManagement/IGameplayState.cs
@@ -9,33 +9,42 @@ using UnityEngine.InputSystem;
 public interface IGameplayState
 {
     /// <summary>
-    /// Unload and prepare a transition to the provided state.
+    /// Processes a change to a new state.
     /// This preserves this state in the stack, for coming back to later.
     /// </summary>
     /// <param name="nextState">State that is being transitioned in to. Should not be null.</param>
-    /// <returns>Yieldable IEnumerator.</returns>
-    IEnumerator TransitionUp(IGameplayState nextState);
+    IEnumerator ChangeUp(IGameplayState nextState);
 
     /// <summary>
-    /// Unload and prepare a transition out of this state.
-    /// This removes it from the stack, so it should be fully cleaned up.
+    /// Plays any animations that are related to this state no longer being at the front.
+    /// </summary>
+    /// <param name="nextState">The state that will be active next.</param>
+    IEnumerator AnimateTransitionOut(IGameplayState nextState);
+
+    /// <summary>
+    /// Process leaving the state, intending to unload it entirely.
     /// </summary>
     /// <param name="nextState">State that is being transitioned in to, under this one. Can be null.</param>
-    /// <returns>Yieldable IEnumerator.</returns>
     IEnumerator ExitState(IGameplayState nextState);
 
     /// <summary>
     /// Load the assets for this state. Does not display them yet.
     /// </summary>
-    /// <returns>Yieldable IEnumerator.</returns>
     IEnumerator Load();
+
+    /// <summary>
+    /// Plays any animations that are related to this state coming to the front.
+    /// At the end of this IEnumerator, the game should be ready to play and receive input.
+    /// Start a coroutine (not yield it) for animations that play while the transitioning is finishing.
+    /// </summary>
+    /// <param name="previousState">The state that was active before this.</param>
+    IEnumerator AnimateTransitionIn(IGameplayState previousState);
 
     /// <summary>
     /// Animate a transition in to this state. At this point the assets should all be loaded and ready for display.
     /// </summary>
     /// <param name="previousState">The state before this one was loaded. Can be null.</param>
     /// <param name="nextState">State that is being transitioned in to.</param>
-    /// <returns>Yieldable IEnumerator.</returns>
     IEnumerator StartState(GlobalStateMachine stateMachine, IGameplayState previousState);
 
     /// <summary>
@@ -43,6 +52,5 @@ public interface IGameplayState
     /// Called whenever a new control method is found, or the state is entered.
     /// </summary>
     /// <param name="activeInput">The input map to update.</param>
-    /// <returns>Yieldable IEnumerator.</returns>
     void SetControls(WarrencrawlInputs activeInput);
 }

--- a/Assets/StateManagement/MainMenu/MainMenuState.cs
+++ b/Assets/StateManagement/MainMenu/MainMenuState.cs
@@ -10,21 +10,4 @@ public class MainMenuState : SceneLoadingGameplayState
     {
         controls.UI.Enable();
     }
-
-    public override IEnumerator ExitState(IGameplayState nextState)
-    {
-        if (nextState != null)
-        {
-            yield return SceneHelperInstance.TransitionsInstance.TransitionIn();
-        }
-
-        yield return base.ExitState(nextState);
-    }
-
-    public override IEnumerator StartState(GlobalStateMachine globalStateMachine, IGameplayState previousState)
-    {
-        yield return base.StartState(globalStateMachine, previousState);
-
-        yield return SceneHelperInstance.TransitionsInstance.ContinueTransitionYieldUntilInputsOK();
-    }
 }

--- a/Assets/StateManagement/SceneHelper/SceneHelper.cs
+++ b/Assets/StateManagement/SceneHelper/SceneHelper.cs
@@ -56,13 +56,9 @@ public class SceneHelper : MonoBehaviour
         GlobalStateMachineInstance = withGSM;
         Inputs = inputs;
 
-        if (!SceneManager.GetAllScenes().Any(sc => sc.name == "SceneHelper"))
+        if (!StaticSceneTools.IsSceneLoaded(nameof(SceneHelper)))
         {
-            AsyncOperation bootstrapperScene = SceneManager.LoadSceneAsync("SceneHelper", LoadSceneMode.Additive);
-            while (!bootstrapperScene.isDone)
-            {
-                yield return bootstrapperScene.progress;
-            }
+            yield return StaticSceneTools.LoadSceneAdditvely(nameof(SceneHelper));
         }
     }
 }

--- a/Assets/StateManagement/SceneHelper/Transitions.controller
+++ b/Assets/StateManagement/SceneHelper/Transitions.controller
@@ -11,7 +11,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -5824052836025032870}
-    m_Position: {x: 290, y: 0, z: 0}
+    m_Position: {x: 310, y: 20, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6721533418270626069}
     m_Position: {x: 540, y: 170, z: 0}
@@ -25,11 +25,12 @@ AnimatorStateMachine:
     m_State: {fileID: 1782218933882105822}
     m_Position: {x: 380, y: 270, z: 0}
   m_ChildStateMachines: []
-  m_AnyStateTransitions: []
+  m_AnyStateTransitions:
+  - {fileID: 7334508593165721432}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_AnyStatePosition: {x: 560, y: 20, z: 0}
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
@@ -199,13 +200,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: FinishTransition
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -379,3 +380,28 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &7334508593165721432
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: StartTransition
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6721533418270626069}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0

--- a/Assets/StateManagement/SceneHelper/Transitions.controller
+++ b/Assets/StateManagement/SceneHelper/Transitions.controller
@@ -142,7 +142,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: TransitionOut
+    m_ConditionEvent: FinishTransition
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1965473248754634408}
@@ -194,18 +194,18 @@ AnimatorController:
   m_Name: Transitions
   serializedVersion: 5
   m_AnimatorParameters:
-  - m_Name: TransitionIn
+  - m_Name: StartTransition
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
-  - m_Name: TransitionOut
+    m_Controller: {fileID: 0}
+  - m_Name: FinishTransition
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -338,7 +338,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: TransitionIn
+    m_ConditionEvent: StartTransition
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -6721533418270626069}
@@ -363,7 +363,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: TransitionOut
+    m_ConditionEvent: FinishTransition
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -1609022964999709347}

--- a/Assets/StateManagement/SceneHelper/Transitions.cs
+++ b/Assets/StateManagement/SceneHelper/Transitions.cs
@@ -2,6 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// Handler for the transition <see cref="Animator"/>, providing yieldable coroutines.
+/// </summary>
 public class Transitions : MonoBehaviour
 {
     public TransitionInputAllowanceState InputAllowance = TransitionInputAllowanceState.NotInTransition;
@@ -9,40 +12,60 @@ public class Transitions : MonoBehaviour
 
     public Animator AnimatorInstance;
 
-    public IEnumerator TransitionIn()
+    /// <summary>
+    /// Starts a transition.
+    /// When this is finished, the system should be ready for <see cref="FinishTransition"/> to play when it is ready.
+    /// </summary>
+    public IEnumerator StartTransition()
     {
         AnimationFinished = false;
 
-        AnimatorInstance.SetTrigger("TransitionIn");
+        AnimatorInstance.SetTrigger("StartTransition");
 
         yield return new WaitUntil(() => AnimationFinished);
     }
 
-    public IEnumerator TransitionOut()
+    /// <summary>
+    /// Continues a transition to its finish.
+    /// After this is finished, the transition should be fully completed and relevant pieces inactive.
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerator FinishTransition()
     {
         AnimationFinished = false;
 
-        AnimatorInstance.SetTrigger("TransitionOut");
+        AnimatorInstance.SetTrigger("FinishTransition");
 
         yield return new WaitUntil(() => AnimationFinished);
     }
 
+    /// <summary>
+    /// Function for setting the current phase of the transition.
+    /// Called by <see cref="AnimationEvent"/>s in the Animator.
+    /// </summary>
+    /// <param name="stage"></param>
     public void SetInputAllowance(TransitionInputAllowanceState stage)
     {
         InputAllowance = stage;
     }
 
+    /// <summary>
+    /// Function for setting the animation state to finished, and to reset waiting variables.
+    /// </summary>
     public void Finished()
     {
         AnimationFinished = true;
         InputAllowance = TransitionInputAllowanceState.NotInTransition;
     }
 
-    public IEnumerator ContinueTransitionYieldUntilInputsOK()
+    /// <summary>
+    /// Runs <see cref="FinishTransition"/>, but returns when the <see cref="InputAllowance"/> is set to InputsOK.
+    /// </summary>
+    public IEnumerator FinishTransitionYieldUntilInputsOK()
     {
         AnimationFinished = false;
 
-        AnimatorInstance.SetTrigger("TransitionOut");
+        AnimatorInstance.SetTrigger("FinishTransition");
 
         yield return new WaitUntil(() => AnimationFinished || InputAllowance == TransitionInputAllowanceState.InputsOK);
     }

--- a/Assets/StateManagement/SceneHelperTools.cs
+++ b/Assets/StateManagement/SceneHelperTools.cs
@@ -15,13 +15,9 @@ public abstract class SceneHelperTools : MonoBehaviour
 
     private IEnumerator Start()
     {
-        if (!SceneManager.GetAllScenes().Any(sc => sc.name == "SceneHelper"))
+        if (!StaticSceneTools.IsSceneLoaded(nameof(SceneHelper)))
         {
-            AsyncOperation bootstrapperScene = SceneManager.LoadSceneAsync("SceneHelper", LoadSceneMode.Additive);
-            while (!bootstrapperScene.isDone)
-            {
-                yield return bootstrapperScene.progress;
-            }
+            yield return StaticSceneTools.LoadSceneAdditvely(nameof(SceneHelper));
         }
 
         SceneHelperInstance = GameObject.FindObjectOfType<SceneHelper>();

--- a/Assets/StateManagement/SceneLoadingGameplayState.cs
+++ b/Assets/StateManagement/SceneLoadingGameplayState.cs
@@ -38,6 +38,16 @@ public abstract class SceneLoadingGameplayState : IGameplayState
         SceneHelperInstance = GameObject.FindObjectOfType<SceneHelper>();
     }
 
+    public virtual IEnumerator AnimateTransitionOut(IGameplayState nextState)
+    {
+        if (nextState == null)
+        {
+            yield break;
+        }
+
+        yield return SceneHelperInstance.TransitionsInstance.StartTransition();
+    }
+
     public virtual IEnumerator ExitState(IGameplayState nextState)
     {
         AsyncOperation unloadScene = SceneManager.UnloadSceneAsync(SceneName);
@@ -53,15 +63,24 @@ public abstract class SceneLoadingGameplayState : IGameplayState
         }
     }
 
+    public virtual IEnumerator AnimateTransitionIn(IGameplayState previousState)
+    {
+        if (previousState == null)
+        {
+            yield break;
+        }
+
+        yield return SceneHelperInstance.TransitionsInstance.FinishTransitionYieldUntilInputsOK();
+    }
+
     public virtual IEnumerator StartState(GlobalStateMachine globalStateMachine, IGameplayState previousState)
     {
-        // TODO: Animated transition system
         StateMachineInstance = globalStateMachine;
 
         yield break;
     }
 
-    public virtual IEnumerator TransitionUp(IGameplayState nextState)
+    public virtual IEnumerator ChangeUp(IGameplayState nextState)
     {
         foreach(GameObject rootObj in SceneManager.GetSceneByName(SceneName).GetRootGameObjects())
         {

--- a/Assets/StateManagement/SceneLoadingGameplayState.cs
+++ b/Assets/StateManagement/SceneLoadingGameplayState.cs
@@ -21,13 +21,9 @@ public abstract class SceneLoadingGameplayState : IGameplayState
 
     public virtual IEnumerator Load()
     {
-        if (!SceneManager.GetAllScenes().Any(sc => sc.name == SceneName))
+        if (!StaticSceneTools.IsSceneLoaded(SceneName))
         {
-            AsyncOperation loadScene = SceneManager.LoadSceneAsync(SceneName, LoadSceneMode.Additive);
-            while (!loadScene.isDone)
-            {
-                yield return loadScene.progress;
-            }
+            yield return StaticSceneTools.LoadSceneAdditvely(SceneName);
         }
 
         foreach (GameObject rootObj in SceneManager.GetSceneByName(SceneName).GetRootGameObjects())
@@ -50,17 +46,7 @@ public abstract class SceneLoadingGameplayState : IGameplayState
 
     public virtual IEnumerator ExitState(IGameplayState nextState)
     {
-        AsyncOperation unloadScene = SceneManager.UnloadSceneAsync(SceneName);
-
-        if (unloadScene == null)
-        {
-            Debug.LogError($"Could not find scene to exit: {GetType()}");
-        }
-
-        while (!unloadScene.isDone)
-        {
-            yield return unloadScene.progress;
-        }
+        yield return StaticSceneTools.UnloadScene(SceneName);
     }
 
     public virtual IEnumerator AnimateTransitionIn(IGameplayState previousState)

--- a/Assets/StateManagement/StaticSceneTools.cs
+++ b/Assets/StateManagement/StaticSceneTools.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceProviders;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Provides a wrapper for yieldable <see cref="SceneManager"/> operations.
+/// </summary>
+public static class StaticSceneTools
+{
+    /// <summary>
+    /// Returns if a scene with a given name is currently loaded.
+    /// </summary>
+    /// <param name="name">The name to check.</param>
+    /// <returns>True if the scene is currently loaded.</returns>
+    public static bool IsSceneLoaded(string name)
+    {
+        for (int ii = 0; ii < SceneManager.sceneCount; ii++)
+        {
+            if (SceneManager.GetSceneAt(ii).name == name)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Loads a scene additively (in addition to scenes already loaded).
+    /// This looks to the bundled scenes; it won't reach in to Addressables.
+    /// Generally used for major state machine states.
+    /// </summary>
+    /// <param name="name">The name of the scene to load.</param>
+    public static IEnumerator LoadSceneAdditvely(string name)
+    {
+        AsyncOperation loadScene = SceneManager.LoadSceneAsync(name, LoadSceneMode.Additive);
+        while (!loadScene.isDone)
+        {
+            yield return loadScene.progress;
+        }
+    }
+
+    /// <summary>
+    /// Loads an addressable scene additively (in addition to scenes already loaded).
+    /// This only looks at scenes that are marked as Addressable.
+    /// Generally used for labyrinth scenes.
+    /// </summary>
+    /// <param name="level">The GameLevel to load the scene for.</param>
+    public static IEnumerator LoadAddressableSceneAdditvely(GameLevel level)
+    {
+        AsyncOperationHandle<SceneInstance> loadingOperation = Addressables.LoadSceneAsync(level, LoadSceneMode.Additive);
+        yield return loadingOperation;
+    }
+
+    /// <summary>
+    /// Unloads a scene with the provided name.
+    /// This can unload either Addressable or standard scenes.
+    /// </summary>
+    /// <param name="name">The name of the scene to unload.</param>
+    public static IEnumerator UnloadScene(string name)
+    {
+        AsyncOperation unloadScene = SceneManager.UnloadSceneAsync(name);
+
+        if (unloadScene == null)
+        {
+            Debug.LogError($"Could not find scene to exit: {name}");
+        }
+
+        while (!unloadScene.isDone)
+        {
+            yield return unloadScene.progress;
+        }
+    }
+}

--- a/Assets/StateManagement/StaticSceneTools.cs.meta
+++ b/Assets/StateManagement/StaticSceneTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66362cbad14086547a36ac883b55713e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StateManagement/Town/TownState.cs
+++ b/Assets/StateManagement/Town/TownState.cs
@@ -10,21 +10,4 @@ public class TownState : SceneLoadingGameplayState
     {
         controls.UI.Enable();
     }
-
-    public override IEnumerator ExitState(IGameplayState nextState)
-    {
-        if (nextState != null)
-        {
-            yield return SceneHelperInstance.TransitionsInstance.TransitionIn();
-        }
-
-        yield return base.ExitState(nextState);
-    }
-
-    public override IEnumerator StartState(GlobalStateMachine globalStateMachine, IGameplayState previousState)
-    {
-        yield return base.StartState(globalStateMachine, previousState);
-
-        yield return SceneHelperInstance.TransitionsInstance.ContinueTransitionYieldUntilInputsOK();
-    }
 }

--- a/Assets/Tests/PlayModeTests/StairInteractiveTests.cs
+++ b/Assets/Tests/PlayModeTests/StairInteractiveTests.cs
@@ -40,7 +40,7 @@ public class StairInteractiveTests
         yield return labyrinthState.Interact();
 
         Assert.That(stateMachine.CurrentState, Is.TypeOf(typeof(TownState)));
-        Assert.That(StaticSceneTools.IsSceneLoaded(labyrinthState.SceneName), Is.True);
+        Assert.That(StaticSceneTools.IsSceneLoaded("Town"), Is.True);
     }
 
     class TestLabyrinthProvider : IGameLevelProvider

--- a/Assets/Tests/PlayModeTests/StairInteractiveTests.cs
+++ b/Assets/Tests/PlayModeTests/StairInteractiveTests.cs
@@ -40,7 +40,7 @@ public class StairInteractiveTests
         yield return labyrinthState.Interact();
 
         Assert.That(stateMachine.CurrentState, Is.TypeOf(typeof(TownState)));
-        Assert.That(SceneManager.GetAllScenes().Any(scene => scene.name == "Town"), Is.True);
+        Assert.That(StaticSceneTools.IsSceneLoaded(labyrinthState.SceneName), Is.True);
     }
 
     class TestLabyrinthProvider : IGameLevelProvider

--- a/Assets/Tests/PlayModeTests/StateManagementTests.cs
+++ b/Assets/Tests/PlayModeTests/StateManagementTests.cs
@@ -31,17 +31,17 @@ public class StateManagementTests
     [UnityTest]
     public IEnumerator PushNewState_ScenesAdding_AddsAndEndsScenes()
     {
-        MainMenuState newState = new MainMenuState();
+        MainMenuState menuState = new MainMenuState();
 
-        yield return stateMachine.PushNewState(newState);
-        Assert.That(stateMachine.CurrentState, Is.EqualTo(newState));
+        yield return stateMachine.PushNewState(menuState);
+        Assert.That(stateMachine.CurrentState, Is.EqualTo(menuState));
 
         // todo: Perhaps we want a function that fetches whether or not a scene is loaded
-        Assert.That(SceneManager.GetAllScenes().Any(scene => scene.name == newState.SceneName), Is.True);
+        Assert.That(StaticSceneTools.IsSceneLoaded(menuState.SceneName), Is.True);
 
         yield return stateMachine.EndCurrentState();
         Assert.That(stateMachine.CurrentState, Is.Null);
-        Assert.That(SceneManager.GetAllScenes().Any(scene => scene.name == newState.SceneName), Is.False);
+        Assert.That(StaticSceneTools.IsSceneLoaded(menuState.SceneName), Is.False);
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixed input bug (#79 and #82) that was storing your relative direction at time of pressing the key, rather than at time of movement execution.
- Created StaticSceneTools (#44, #52, #53) for more consistently and easily loading and unloading scenes
- Made an explicit animation step for transitions (#78)